### PR TITLE
Fix preview height for small media

### DIFF
--- a/js/Main.js
+++ b/js/Main.js
@@ -869,7 +869,14 @@ var RedditBoostPlugin;
             else {
                 this._centerPopupVertically(popupHeight);
             }
-            $("#RedditBoost_loadingAnimation").css("left", popupWidth / 2 - 100);
+            var display = $("#RedditBoost_loadingAnimation").css('display');
+            if ($("#RedditBoost_loadingAnimation").css('display') == 'block') {
+                $("#RedditBoost_loadingAnimation").css("left", popupWidth / 2 - 100);
+                $("#RedditBoost_imagePopup").css("min-height", 220);
+            }
+            else {
+                $("#RedditBoost_imagePopup").css("min-height", 0);
+            }
         };
         HoverPreviewPlugin.prototype._findMostSpace = function (mouseLocation) {
             var windowWidth = $(window).width();

--- a/styles.css
+++ b/styles.css
@@ -100,7 +100,6 @@
 	background-color: white;
 	z-index: 10000;
 	min-width: 200px;
-	min-height: 220px;
 }
 
 #RedditBoost_imagePopup .RedditBoost_Content {

--- a/ts/features/HoverPreview.ts
+++ b/ts/features/HoverPreview.ts
@@ -447,7 +447,13 @@ module RedditBoostPlugin {
             }
             
             // Update loading animation position
-            $("#RedditBoost_loadingAnimation").css("left", popupWidth/2 - 100);
+            let display = $("#RedditBoost_loadingAnimation").css('display');
+            if ($("#RedditBoost_loadingAnimation").css('display') == 'block') {
+                $("#RedditBoost_loadingAnimation").css("left", popupWidth/2 - 100);
+                $("#RedditBoost_imagePopup").css("min-height", 220);
+            } else {
+                $("#RedditBoost_imagePopup").css("min-height", 0);
+            }
         }
         
         /**


### PR DESCRIPTION
The minimum height for popups was set to 220px to account for the height of the absolutely positioned loading animation; however, sometimes images are smaller than that height. This fix only applies the minimum height while the loading animation is visibile.
